### PR TITLE
style: improve readability

### DIFF
--- a/lib/components/ChangelogList/MinimalChangelogList.tsx
+++ b/lib/components/ChangelogList/MinimalChangelogList.tsx
@@ -44,6 +44,7 @@ export const MinimalChangelogList: React.FC<Props> = ({
           changelogs={componentChangelogs}
           changeTypeMapper={changeTypeMapper}
           typeColorResolver={getTypeColor}
+          hideEntryType
         />
       )}
     </>

--- a/lib/components/ChangelogList/_internal/ComponentList.tsx
+++ b/lib/components/ChangelogList/_internal/ComponentList.tsx
@@ -19,7 +19,7 @@ const ComponentList: React.FC<Props> = ({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        gap: 6,
+        gap: 3,
       }}
     >
       {changelogs.map((changelog, index) => (
@@ -79,6 +79,7 @@ const ComponentList: React.FC<Props> = ({
                         sx={{
                           color: typeColorResolver(entry.changeType),
                         }}
+                        variant={'outlined'}
                       >
                         {changeTypeMapper[entry.changeType]}
                       </Chip>

--- a/lib/components/ChangelogList/_internal/ComponentList.tsx
+++ b/lib/components/ChangelogList/_internal/ComponentList.tsx
@@ -1,4 +1,4 @@
-import { Box, List, ListItem, Typography } from '@mui/joy';
+import { Box, Divider, List, ListItem, Typography } from '@mui/joy';
 import * as React from 'react';
 import { ChangeType } from '../../../changelog.types.ts';
 import { ChangelogWithComponents } from '../../changelog.util.ts';
@@ -22,6 +22,12 @@ const ComponentList: React.FC<Props> = ({
             <Typography level="h3" sx={() => ({ mr: 1 })}>
               Version {changelog.version}
             </Typography>
+            <Divider
+              sx={{
+                mt: 1,
+                mb: 2,
+              }}
+            />
             {changelog.description && (
               <Typography>{changelog.description}</Typography>
             )}

--- a/lib/components/ChangelogList/_internal/ComponentList.tsx
+++ b/lib/components/ChangelogList/_internal/ComponentList.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, List, ListItem, Typography } from '@mui/joy';
+import { Box, Card, CardContent, Chip, Divider, Typography } from '@mui/joy';
 import * as React from 'react';
 import { ChangeType } from '../../../changelog.types.ts';
 import { ChangelogWithComponents } from '../../changelog.util.ts';
@@ -23,63 +23,72 @@ const ComponentList: React.FC<Props> = ({
       }}
     >
       {changelogs.map((changelog, index) => (
-        <div key={`changelogs-${index}`}>
-          <Box sx={() => ({ mb: 2 })}>
+        <Card key={`changelogs-${index}`} variant={'soft'}>
+          <Box sx={() => ({ mb: 1 })}>
             <Typography level="h1">Version {changelog.version}</Typography>
             <Divider
               sx={{
                 mt: 1,
                 mb: 2,
+                mx: -2,
               }}
             />
             {changelog.description && (
-              <Typography>{changelog.description}</Typography>
+              <Typography color={'neutral'}>{changelog.description}</Typography>
             )}
           </Box>
-          <Box
+          <CardContent
             sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 1,
+              gap: 2,
             }}
           >
             {changelog.entries.map((entry) => (
-              <div key={`changelogs-${index}-components-${entry.component}`}>
+              <Card
+                key={`changelogs-${index}-components-${entry.component}`}
+                variant={'outlined'}
+              >
                 {entry.component && (
-                  <Typography level="title-lg">{entry.component}</Typography>
+                  <>
+                    <Typography level="title-lg">{entry.component}</Typography>
+                    <Divider
+                      sx={{
+                        mx: -2,
+                      }}
+                    />
+                  </>
                 )}
-                <List
-                  marker={'circle'}
-                  sx={() => ({ '--ListItem-minHeight': 20 })}
+                <CardContent
+                  sx={{
+                    gap: 2,
+                  }}
                 >
                   {entry.changelogs.map((entry, entryIndex) => (
-                    <ListItem
-                      sx={{ p: 0 }}
+                    <Box
                       key={`changelogs-${changelog.version}-entry-${entryIndex}`}
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 0.5,
+                        alignItems: 'flex-start',
+                      }}
                     >
-                      <Box
-                        sx={() => ({ display: 'flex', flexDirection: 'row' })}
+                      <Typography level="body-sm">
+                        {entry.description}
+                      </Typography>
+                      <Chip
+                        sx={{
+                          color: typeColorResolver(entry.changeType),
+                        }}
                       >
-                        <Typography
-                          level="title-sm"
-                          sx={{
-                            mr: 1,
-                            color: typeColorResolver(entry.changeType),
-                          }}
-                        >
-                          {changeTypeMapper[entry.changeType]}
-                        </Typography>
-                        <Typography level="body-sm">
-                          {entry.description}
-                        </Typography>
-                      </Box>
-                    </ListItem>
+                        {changeTypeMapper[entry.changeType]}
+                      </Chip>
+                    </Box>
                   ))}
-                </List>
-              </div>
+                </CardContent>
+              </Card>
             ))}
-          </Box>
-        </div>
+          </CardContent>
+        </Card>
       ))}
     </Box>
   );

--- a/lib/components/ChangelogList/_internal/ComponentList.tsx
+++ b/lib/components/ChangelogList/_internal/ComponentList.tsx
@@ -15,13 +15,17 @@ const ComponentList: React.FC<Props> = ({
   typeColorResolver,
 }) => {
   return (
-    <>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
       {changelogs.map((changelog, index) => (
         <div key={`changelogs-${index}`}>
-          <Box sx={() => ({ mb: 1 })}>
-            <Typography level="h3" sx={() => ({ mr: 1 })}>
-              Version {changelog.version}
-            </Typography>
+          <Box sx={() => ({ mb: 2 })}>
+            <Typography level="h1">Version {changelog.version}</Typography>
             <Divider
               sx={{
                 mt: 1,
@@ -32,42 +36,52 @@ const ComponentList: React.FC<Props> = ({
               <Typography>{changelog.description}</Typography>
             )}
           </Box>
-          {changelog.entries.map((entry) => (
-            <div key={`changelogs-${index}-components-${entry.component}`}>
-              {entry.component && (
-                <Typography level="title-lg">{entry.component}</Typography>
-              )}
-              <List
-                marker={'circle'}
-                sx={() => ({ '--ListItem-minHeight': 20 })}
-              >
-                {entry.changelogs.map((entry, entryIndex) => (
-                  <ListItem
-                    sx={() => ({ p: 0 })}
-                    key={`changelogs-${changelog.version}-entry-${entryIndex}`}
-                  >
-                    <Box sx={() => ({ display: 'flex', flexDirection: 'row' })}>
-                      <Typography
-                        level="title-sm"
-                        sx={() => ({
-                          mr: 1,
-                          color: typeColorResolver(entry.changeType),
-                        })}
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+            }}
+          >
+            {changelog.entries.map((entry) => (
+              <div key={`changelogs-${index}-components-${entry.component}`}>
+                {entry.component && (
+                  <Typography level="title-lg">{entry.component}</Typography>
+                )}
+                <List
+                  marker={'circle'}
+                  sx={() => ({ '--ListItem-minHeight': 20 })}
+                >
+                  {entry.changelogs.map((entry, entryIndex) => (
+                    <ListItem
+                      sx={{ p: 0 }}
+                      key={`changelogs-${changelog.version}-entry-${entryIndex}`}
+                    >
+                      <Box
+                        sx={() => ({ display: 'flex', flexDirection: 'row' })}
                       >
-                        {changeTypeMapper[entry.changeType]}
-                      </Typography>
-                      <Typography level="body-sm">
-                        {entry.description}
-                      </Typography>
-                    </Box>
-                  </ListItem>
-                ))}
-              </List>
-            </div>
-          ))}
+                        <Typography
+                          level="title-sm"
+                          sx={{
+                            mr: 1,
+                            color: typeColorResolver(entry.changeType),
+                          }}
+                        >
+                          {changeTypeMapper[entry.changeType]}
+                        </Typography>
+                        <Typography level="body-sm">
+                          {entry.description}
+                        </Typography>
+                      </Box>
+                    </ListItem>
+                  ))}
+                </List>
+              </div>
+            ))}
+          </Box>
         </div>
       ))}
-    </>
+    </Box>
   );
 };
 

--- a/lib/components/ChangelogList/_internal/ComponentList.tsx
+++ b/lib/components/ChangelogList/_internal/ComponentList.tsx
@@ -67,17 +67,19 @@ const ComponentList: React.FC<Props> = ({
                       key={`changelogs-${changelog.version}-entry-${entryIndex}`}
                       sx={{
                         display: 'flex',
-                        flexDirection: 'column',
+                        flexDirection: 'row',
                         gap: 0.5,
-                        alignItems: 'flex-start',
+                        alignItems: 'baseline',
                       }}
                     >
-                      <Typography level="body-sm">
+                      <Typography level="body-sm" sx={{ flexGrow: 1 }}>
                         {entry.description}
                       </Typography>
                       <Chip
                         sx={{
                           color: typeColorResolver(entry.changeType),
+                          flexShrink: 0,
+                          width: 'auto',
                         }}
                         variant={'outlined'}
                       >

--- a/lib/components/ChangelogList/_internal/ComponentList.tsx
+++ b/lib/components/ChangelogList/_internal/ComponentList.tsx
@@ -7,12 +7,14 @@ interface Props {
   changelogs: ChangelogWithComponents[];
   changeTypeMapper: Record<ChangeType, string>;
   typeColorResolver: (type: ChangeType) => string;
+  hideEntryType?: boolean;
 }
 
 const ComponentList: React.FC<Props> = ({
   changelogs,
   changeTypeMapper,
   typeColorResolver,
+  hideEntryType = false,
 }) => {
   return (
     <Box
@@ -75,16 +77,18 @@ const ComponentList: React.FC<Props> = ({
                       <Typography level="body-sm" sx={{ flexGrow: 1 }}>
                         {entry.description}
                       </Typography>
-                      <Chip
-                        sx={{
-                          color: typeColorResolver(entry.changeType),
-                          flexShrink: 0,
-                          width: 'auto',
-                        }}
-                        variant={'outlined'}
-                      >
-                        {changeTypeMapper[entry.changeType]}
-                      </Chip>
+                      {!hideEntryType && (
+                        <Chip
+                          sx={{
+                            color: typeColorResolver(entry.changeType),
+                            flexShrink: 0,
+                            width: 'auto',
+                          }}
+                          variant={'outlined'}
+                        >
+                          {changeTypeMapper[entry.changeType]}
+                        </Chip>
+                      )}
                     </Box>
                   ))}
                 </CardContent>

--- a/lib/components/changelog.util.ts
+++ b/lib/components/changelog.util.ts
@@ -5,13 +5,13 @@ import {
 } from '../changelog.types.ts';
 
 export const ChangeTypeMap: Record<ChangeType, string> = {
-  [ChangeType.FEATURE]: '[Neu]',
-  [ChangeType.IMPROVEMENT]: '[Angegepasst]',
-  [ChangeType.FIX]: '[Behoben]',
-  [ChangeType.NOTE]: '[Notiz]',
-  [ChangeType.BREAKING]: '[Geändertes Verhalten]',
-  [ChangeType.KNOWNISSUE]: '[Bekanntes Problem]',
-  [ChangeType.REMOVED]: '[Entfernt]',
+  [ChangeType.FEATURE]: 'Neu',
+  [ChangeType.IMPROVEMENT]: 'Angegepasst',
+  [ChangeType.FIX]: 'Behoben',
+  [ChangeType.NOTE]: 'Notiz',
+  [ChangeType.BREAKING]: 'Geändertes Verhalten',
+  [ChangeType.KNOWNISSUE]: 'Bekanntes Problem',
+  [ChangeType.REMOVED]: 'Entfernt',
 };
 
 export const getTypeColor = (type: ChangeType): string => {


### PR DESCRIPTION
Trying to improve UX in terms of readability and seperation of context. For visual encapsulation I took inspiration from https://dribbble.com/shots/23533976-Changelog-Card
* clearer separation of indivudial versions
* clearer separation of indivudial components inside a version
* typography adjustments in terms of size and color
* spacing adjustments in terms of sepeartion and context

Here is a before and after
![image](https://github.com/user-attachments/assets/365f842b-4f10-4b01-ab81-a8a07b0730e9)
![image](https://github.com/user-attachments/assets/664249ce-7db9-4e80-88c7-54bf4031c0c1)
